### PR TITLE
Added options page with option to open in new tab

### DIFF
--- a/content.js
+++ b/content.js
@@ -18,11 +18,25 @@
    * Switch to/from the WordPress Admin.
    */
   function toggleAdmin() {
-    if (isWordPressAdmin(window.location.pathname)) {
-      window.location = getFrontEndUrl();
-    } else {
-      window.location = getAdminUrl();
-    }
+    getSettings((settings) => {
+      const openInNewTab = settings.openInNewTab;
+      const adminUrl = getAdminUrl();
+      const frontEndUrl = getFrontEndUrl();
+
+      if (isWordPressAdmin(window.location.pathname)) {
+        if (openInNewTab) {
+          window.open(frontEndUrl, '_blank');
+        } else {
+          window.location = frontEndUrl;
+        }
+      } else {
+        if (openInNewTab) {
+          window.open(adminUrl, '_blank');
+        } else {
+          window.location = adminUrl;
+        }
+      }
+    });
   }
 
   /**
@@ -512,6 +526,17 @@
     if (url.endsWith("/")) return url;
 
     return url + "/";
+  }
+
+  /**
+   * Get the extension settings.
+   *
+   * @param {function} callback The callback function to handle the settings.
+   */
+  function getSettings(callback) {
+    chrome.storage.sync.get(['openInNewTab'], (settings) => {
+      callback(settings);
+    });
   }
 
   // Add event listener

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,12 @@
   "name": "WordPress Admin Switcher",
   "short_name": "WPAdminSwitcher",
   "description": "Quickly log into and switch to/from the WordPress Admin with a single keyboard shortcut or click.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage_url": "https://github.com/kellenmace/wp-admin-switcher/",
   "manifest_version": 3,
+  "permissions": [
+    "storage"
+  ],
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*"],
@@ -28,5 +31,6 @@
       },
       "description": "Switch to/from admin"
     }
-  }
+  },
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <title>WordPress Admin Switcher Options</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .heading-container {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+
+        .heading-container h1 {
+            color: #404040;
+            margin: 0;
+        }
+
+        label {
+            display: flex;
+            align-items: center;
+        }
+
+        input {
+            cursor: pointer;
+        }
+
+        button {
+            background-color: #404040;
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            padding: 10px 10px;
+            margin-top: 20px;
+            font-size: 16px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="heading-container">
+            <img id="plugin-icon" src="images/icon-38.png" alt="WordPress Admin Switcher Icon" width="38" height="38" />
+            <h1>WordPress Admin Switcher</h1>
+        </div>
+        <h2>Options</h2>
+        <label>
+            <input type="checkbox" id="openInNewTab">
+            Open admin page in new tab
+        </label>
+        <div class="save-button-container">
+            <button id="save">Save</button>
+        </div>
+    </div>
+    <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const openInNewTabCheckbox = document.getElementById('openInNewTab');
+    const saveButton = document.getElementById('save');
+      
+    // Load settings
+    chrome.storage.sync.get(['openInNewTab'], (settings) => {
+      openInNewTabCheckbox.checked = settings.openInNewTab || false;
+    });
+  
+    // Save settings
+    saveButton.addEventListener('click', () => {
+      chrome.storage.sync.set({
+        openInNewTab: openInNewTabCheckbox.checked
+      }, () => {
+        alert('Settings saved');
+      });
+    });
+  });


### PR DESCRIPTION
I wanted to be able to open the admin page in a new tab instead of just opening it directly. So I added a new options page where you can toggle whether or not you want it to open in a new tab or not (defaults to not open in new tab). Please consider merging. Thank you!